### PR TITLE
Init post launch page; Add and style hero

### DIFF
--- a/pages/full.js
+++ b/pages/full.js
@@ -1,0 +1,54 @@
+import { Button, PageHeading, SectionText, SiteHeader } from 'components'
+import styles from 'styles/full.module.css'
+
+const Full = () => (
+  <div className={`${styles.contentRoot}`}>
+    <section className={styles.hero}>
+      <SiteHeader />
+      <div className={`${styles.sectionContent}`}>
+        <div className={styles.heroContent}>
+          <PageHeading className={styles.heroHeading}>
+            We are the community for{' '}
+            <span className={styles.highlight}>remote-first</span> Software
+            Engineers
+          </PageHeading>
+          <SectionText className={styles.heroText}>
+            Commit is designing the future of work and we're putting Engineers
+            at the center.
+          </SectionText>
+          <Button className={styles.heroButton}>Apply to Join Us</Button>
+        </div>
+        <div className={styles.heroSvg}>
+          <svg
+            width="272"
+            height="639"
+            viewBox="0 0 272 639"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256.047 0.0012207H272V68.2663H256.047C235.401 68.0679 215.494 75.752 200.578 89.677C185.663 103.602 176.92 122.664 176.219 142.791C176.219 148.753 176.219 155.55 176.219 162.228C176.219 211.235 176.219 274.671 134.778 319.386C176.525 364.101 176.342 427.537 176.219 476.604C176.219 483.222 176.219 489.721 176.219 496.041C176.92 516.168 185.663 535.23 200.578 549.155C215.494 563.08 235.401 570.764 256.047 570.566H272V638.771H256.047C217.039 638.924 179.521 624.17 151.53 597.67C123.538 571.17 107.3 535.031 106.294 496.995C106.294 490.317 106.294 483.461 106.294 476.426C106.294 413.407 103.421 370.54 61.4903 349.852L0 319.386L61.4903 288.98C103.421 268.232 106.477 225.365 106.294 162.406C106.294 155.371 106.294 148.456 106.294 141.838C107.285 103.791 123.516 67.637 151.509 41.124C179.502 14.6109 217.029 -0.151428 256.047 0.0012207Z"
+              fill="url(#paint0_linear)"
+              fillOpacity="0.2"
+            />
+            <defs>
+              <linearGradient
+                id="paint0_linear"
+                x1="272"
+                y1="319"
+                x2="0"
+                y2="319"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stopColor="#68B5FF" />
+                <stop offset="1" stopColor="#54FFFF" />
+              </linearGradient>
+            </defs>
+          </svg>
+        </div>
+      </div>
+    </section>
+  </div>
+)
+
+export default Full

--- a/styles/full.module.css
+++ b/styles/full.module.css
@@ -1,0 +1,113 @@
+/* Shared Styles */
+.contentRoot {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  overflow: hidden;
+  padding: 0px;
+  margin: 0px;
+}
+
+.sectionContent {
+  margin: 0 auto;
+  padding: 0 120px;
+}
+
+@media only screen and (max-width: 1023px) {
+  .sectionContent {
+    padding: 0 8%;
+  }
+}
+
+@media only screen and (max-width: 413px) {
+  .sectionContent {
+    padding: 0 36px;
+  }
+}
+
+/* Hero Styles */
+.hero {
+  background: linear-gradient(68.66deg, #0f1011 0%, #010242 100%);
+  color: #ffffff;
+  overflow: hidden;
+  min-height: 946px;
+}
+.heroSvg {
+  position: absolute;
+  right: 0;
+  top: 180px;
+}
+.heroContent {
+  max-width: 50rem;
+}
+.hero .sectionContent {
+  display: flex;
+  padding-right: 0px;
+  justify-content: space-between;
+}
+h1.heroHeading {
+  margin-top: 200px;
+  margin-bottom: 4.5rem;
+  text-align: left;
+}
+h1.heroHeading .highlight {
+  color: #54ffff;
+}
+p.heroText {
+  color: #8493b0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 2.25rem;
+  margin-bottom: 4.5rem;
+}
+button.heroButton {
+  max-width: 380px;
+}
+
+@media only screen and (max-width: 1023px) {
+  .heroContent {
+    width: 65%;
+  }
+  h1.heroHeading {
+    font-size: 3rem;
+    line-height: 3.625rem;
+    margin-top: 180px;
+    margin-bottom: 4.25rem;
+  }
+  button.heroButton {
+    max-width: 100%;
+    min-width: 100%;
+  }
+}
+
+@media only screen and (max-width: 413px) {
+  .hero {
+    background: #000000;
+    min-height: 820px;
+  }
+  .hero .sectionContent {
+    padding: 0 36px;
+  }
+  .heroContent {
+    width: initial;
+  }
+  .heroSvg {
+    display: none;
+  }
+  h1.heroHeading {
+    font-size: 2rem;
+    line-height: 2.375rem;
+    margin-top: 140px;
+    margin-bottom: 3rem;
+  }
+  p.heroText {
+    font-size: 1.5rem;
+    font-weight: 500;
+    line-height: 2rem;
+    margin-bottom: 3rem;
+  }
+  button.heroButton {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&family=Montserrat:wght@500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&family=Montserrat:wght@500;600;700&display=swap');
 
 html,
 body {


### PR DESCRIPTION
## What Changed
- Creating post-launch page (currently under /full path as in full-page, open to better ideas)
- Adding and styling hero section of post-launch page

## Screenshots
![Kapture 2021-01-22 at 13 01 45](https://user-images.githubusercontent.com/5143561/105546403-3222af00-5cb2-11eb-86fd-11642d2e1e91.gif)
