### PR TITLE
Use new components that were setup for Heading and Text

### DIFF
--- a/components/heading/index.js
+++ b/components/heading/index.js
@@ -30,7 +30,20 @@ const StyledHeading1 = styled.h1`
   line-height: ${rem('80px')};
   letter-spacing: 0rem;
   margin-top: ${rem('12px')};
+
+  @media only screen and (max-width: 1023px) {
+    font-size: ${rem('48px')};
+    line-height: ${rem('60px')};
+  }
+
+  @media only screen and (max-width: 413px) {
+    font-size: ${rem('32px')};
+    line-height: ${rem('40px')};
+  }
 `
+
+// TODO: confirm styles below
+
 const StyledHeading2 = styled.h2`
   font-size: 1.125rem;
   font-weight: 800;

--- a/components/text/index.js
+++ b/components/text/index.js
@@ -2,37 +2,41 @@ import { rem } from 'polished'
 import styled, { css } from 'styled-components'
 
 const StyledText = styled.p`
-  font-size: 1rem;
+  font-size: ${rem('16px')};
   font-weight: 500;
-  line-height: 1.625rem;
+  line-height: ${rem('24px')};
   letter-spacing: 0rem;
   text-align: left;
-  margin-top: 0.25rem;
+  margin-top: ${rem('16px')};
 
-  @media only screen and (max-width: 767px) {
+  @media only screen and (max-width: 1023px) {
     text-align: center;
+  }
 
-    :last-of-type {
-      margin-bottom: 5.25rem;
-    }
+  @media only screen and (max-width: 413px) {
+    text-align: center;
   }
 
   ${(props) =>
-    props.successText &&
+    props.sectionText &&
     css`
-      font-weight: normal;
-      font-size: 18px;
+      font-weight: 600;
+      font-size: ${rem('20px')};
+      line-height: ${rem('32px')};
+      text-align: center;
       margin-top: ${rem('24px')};
-      margin-bottom: ${rem('24px')};
-    `}
+      margin-top: ${rem('64px')};
+      color: #8493b0;
 
-  ${(props) =>
-    props.errorText &&
-    css`
-      line-height: 21px;
-      color: #ff4545;
-      margin-top: ${rem('24px')};
-      margin-bottom: ${rem('24px')};
+      @media only screen and (max-width: 1023px) {
+      }
+
+      @media only screen and (max-width: 413px) {
+        font-weight: 700;
+        font-size: ${rem('16px')};
+        line-height: ${rem('24px')};
+        margin-top: ${rem('80px')};
+      }
     `}
 `
 

--- a/pages/full.js
+++ b/pages/full.js
@@ -1,4 +1,6 @@
-import { Button, PageHeading, SectionText, SiteHeader } from 'components'
+// TODO: this will replace pages/index.js eventually. Keeping separate to avoid merge conflicts for now
+
+import { Button, Heading, Text, SiteHeader } from 'components'
 import styles from 'styles/full.module.css'
 
 const Full = () => (
@@ -7,15 +9,15 @@ const Full = () => (
       <SiteHeader />
       <div className={`${styles.sectionContent}`}>
         <div className={styles.heroContent}>
-          <PageHeading className={styles.heroHeading}>
+          <Heading className={styles.heroHeading}>
             We are the community for{' '}
             <span className={styles.highlight}>remote-first</span> Software
             Engineers
-          </PageHeading>
-          <SectionText className={styles.heroText}>
+          </Heading>
+          <Text sectionText className={styles.heroText}>
             Commit is designing the future of work and we're putting Engineers
             at the center.
-          </SectionText>
+          </Text>
           <Button className={styles.heroButton}>Apply to Join Us</Button>
         </div>
         <div className={styles.heroSvg}>

--- a/styles/full.module.css
+++ b/styles/full.module.css
@@ -48,17 +48,16 @@
 h1.heroHeading {
   margin-top: 200px;
   margin-bottom: 4.5rem;
-  text-align: left;
 }
 h1.heroHeading .highlight {
   color: #54ffff;
 }
 p.heroText {
-  color: #8493b0;
   font-size: 1.5rem;
   font-weight: 600;
   line-height: 2.25rem;
   margin-bottom: 4.5rem;
+  text-align: left;
 }
 button.heroButton {
   max-width: 380px;
@@ -69,8 +68,6 @@ button.heroButton {
     width: 65%;
   }
   h1.heroHeading {
-    font-size: 3rem;
-    line-height: 3.625rem;
     margin-top: 180px;
     margin-bottom: 4.25rem;
   }
@@ -95,8 +92,6 @@ button.heroButton {
     display: none;
   }
   h1.heroHeading {
-    font-size: 2rem;
-    line-height: 2.375rem;
     margin-top: 140px;
     margin-bottom: 3rem;
   }


### PR DESCRIPTION
## What Changed?
- Visuals should look the same, just updating to use new components that replaced ones that were previously used
- Fixes some import issues that were introduced on Friday due to rebase against main branch I'm guessing

## Screenshots
![Kapture 2021-01-25 at 11 21 10](https://user-images.githubusercontent.com/5143561/105754913-78b91900-5eff-11eb-9f26-4b5809708f0f.gif)
