### PR TITLE
disable alphabetical ordering of imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,4 @@
 const rules = {
-  // import/exports
   'import/exports-last': 'error',
   'import/prefer-default-export': 'off',
   'import/order': [
@@ -7,10 +6,6 @@ const rules = {
     {
       groups: ['builtin', 'external', 'internal'],
       'newlines-between': 'never',
-      alphabetize: {
-        order: 'asc',
-        caseInsensitive: true,
-      },
     },
   ],
   'no-async-promise-executor': 'off',

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
-const rules  = {
+const rules = {
   printWidth: 80,
   singleQuote: true,
   trailingComma: 'all',
@@ -6,7 +6,7 @@ const rules  = {
   jsxBracketSameLine: false,
   parser: 'babel',
   semi: false,
-};
+}
 module.exports = {
-    rules
+  rules,
 }


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [ ] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Removed the alphabetical order rule for imports because it is not playing nice with the vscode `prettier-eslint` extension.

With the rule on internal modules can be sorted outside of their group to the top of the imports:
<img width="753" alt="Screen Shot 2021-02-11 at 4 49 23 PM" src="https://user-images.githubusercontent.com/10035832/107719057-2b250600-6c8c-11eb-9a5c-f6f13017d228.png">

Without the rule imports will be at least sorted into the right group:
<img width="523" alt="Screen Shot 2021-02-11 at 4 50 14 PM" src="https://user-images.githubusercontent.com/10035832/107719094-4263f380-6c8c-11eb-8182-d4519a8b1ff8.png">


> Related Issue: None
