### PR TITLE
update import/order eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,31 @@ const rules = {
     'error',
     {
       groups: ['builtin', 'external', 'internal'],
-      'newlines-between': 'never',
+      pathGroups: [
+        {
+          pattern: 'react',
+          group: 'external',
+          position: 'before',
+        },
+        {
+          pattern: 'components',
+          group: 'internal',
+        },
+        {
+          pattern: 'pages/**',
+          group: 'internal',
+        },
+        {
+          pattern: 'helpers/**',
+          group: 'internal',
+        },
+        {
+          pattern: 'styles/**',
+          group: 'internal',
+        },
+      ],
+      pathGroupsExcludedImportTypes: ['react'],
+      'newlines-between': 'always',
       alphabetize: {
         order: 'asc',
         caseInsensitive: true,

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
-const rules  = {
+const rules = {
   printWidth: 80,
   singleQuote: true,
   trailingComma: 'all',
@@ -6,7 +6,7 @@ const rules  = {
   jsxBracketSameLine: false,
   parser: 'babel',
   semi: false,
-};
+}
 module.exports = {
-    rules
+  rules,
 }

--- a/components/article-preview/index.js
+++ b/components/article-preview/index.js
@@ -1,5 +1,6 @@
 import { string } from 'prop-types'
 import styled from 'styled-components'
+
 import { Heading, Text } from 'components'
 
 const Root = styled.div`

--- a/components/footer/index.js
+++ b/components/footer/index.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+
 import { Text, ApplyLink } from 'components'
 
 const FooterContainer = styled.footer`

--- a/components/form/index.js
+++ b/components/form/index.js
@@ -1,7 +1,9 @@
+import { useEffect, useState } from 'react'
+
 import { CheckCircle } from 'phosphor-react'
 import { rem } from 'polished'
-import { useEffect, useState } from 'react'
 import styled from 'styled-components'
+
 import Button from '../button'
 import Input from '../input'
 import Text from '../text'

--- a/components/site-header/compact.js
+++ b/components/site-header/compact.js
@@ -1,9 +1,12 @@
+import React, { useEffect, useState } from 'react'
+
 import { rem } from 'polished'
 import { bool, func, string, oneOf } from 'prop-types'
-import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
 import styled, { css } from 'styled-components'
+
 import { usePrevious } from 'helpers/hooks'
+
 import { COLOR_VARIATIONS } from './constants'
 import HamburgerMenu from './hamburger-menu'
 import Links from './links'

--- a/components/site-header/hamburger-menu.js
+++ b/components/site-header/hamburger-menu.js
@@ -1,6 +1,8 @@
-import { bool, func, string, oneOf } from 'prop-types'
 import React from 'react'
+
+import { bool, func, string, oneOf } from 'prop-types'
 import styled, { css } from 'styled-components'
+
 import { COLOR_VARIATIONS } from './constants'
 
 const NOOP = () => {}

--- a/components/site-header/index.js
+++ b/components/site-header/index.js
@@ -1,6 +1,7 @@
 import { rem } from 'polished'
 import { oneOf } from 'prop-types'
 import styled from 'styled-components'
+
 import CompactMenu from './compact'
 import { COLOR_VARIATIONS } from './constants'
 import Logo from './logo'

--- a/components/site-header/logo.js
+++ b/components/site-header/logo.js
@@ -1,6 +1,7 @@
 import { rem } from 'polished'
 import { oneOf } from 'prop-types'
 import styled from 'styled-components'
+
 import { COLOR_VARIATIONS } from './constants'
 
 const LogoImg = styled.img`

--- a/components/site-header/standard.js
+++ b/components/site-header/standard.js
@@ -1,5 +1,6 @@
 import { oneOf } from 'prop-types'
 import styled from 'styled-components'
+
 import { COLOR_VARIATIONS } from './constants'
 import Links from './links'
 

--- a/components/testimonials/index.js
+++ b/components/testimonials/index.js
@@ -1,7 +1,9 @@
+import { useEffect } from 'react'
+
 import Glide from '@glidejs/glide'
 import { rem } from 'polished'
-import { useEffect } from 'react'
 import styled from 'styled-components'
+
 import Slide from './slide'
 import '@glidejs/glide/dist/css/glide.core.min.css'
 import '@glidejs/glide/dist/css/glide.theme.min.css'

--- a/components/testimonials/slide.js
+++ b/components/testimonials/slide.js
@@ -1,6 +1,7 @@
 import { rem } from 'polished'
 import { string } from 'prop-types'
 import styled from 'styled-components'
+
 import { Heading, Text } from 'components'
 
 const IMG_WIDTH = '280px'


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [x] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Updated #78 using @jasondippel's example of the import/order rule working better with groups and alphabetization.

I also changed the newlines-between rule to always to make it clearer that imports are organized into groups.

> Related Issue: #78 

## Screenshots
Grouping not being respected when alphabetizing:
<img width="753" alt="Screen Shot 2021-02-11 at 4 49 23 PM" src="https://user-images.githubusercontent.com/10035832/107806803-26a82e00-6d1c-11eb-832e-3f658ba8474f.png">

Result of the updated rules:
<img width="515" alt="Screen Shot 2021-02-12 at 10 21 43 AM" src="https://user-images.githubusercontent.com/10035832/107806877-43dcfc80-6d1c-11eb-906e-383a9ded8ae0.png">
