### PR TITLE
Fix mobile About and Home nav links - Issue #93

### DIFF
--- a/components/site-header/compact.js
+++ b/components/site-header/compact.js
@@ -77,7 +77,7 @@ const NavOverlay = React.forwardRef(
       return ReactDOM.createPortal(
         <NavOverlayRoot id={id} isOpen={isOpen} {...props}>
           <FauxHeader>
-            <Logo />
+            <Logo closeMenu={closeMenu}/>
             <HamburgerMenu
               isOpen={isOpen}
               handleClick={closeMenu}
@@ -87,7 +87,7 @@ const NavOverlay = React.forwardRef(
             />
           </FauxHeader>
           <Nav>
-            <Links onClick={closeMenu} />
+            <Links closeMenu={closeMenu} />
           </Nav>
         </NavOverlayRoot>,
         document.querySelector('body'),

--- a/components/site-header/links.js
+++ b/components/site-header/links.js
@@ -9,10 +9,10 @@ const Anchor = styled.a`
 `
 
 // TODO: update links once pages exist
-const Links = () => (
+const Links = ({ closeMenu }) => (
   <>
     <Link href="/about" passHref>
-      <Anchor>About</Anchor>
+      <Anchor onClick={closeMenu}>About</Anchor>
     </Link>
     <Anchor href="https://blog.commit.dev/" target="_blank" rel="noreferrer">
       Blog

--- a/components/site-header/logo.js
+++ b/components/site-header/logo.js
@@ -26,9 +26,9 @@ const Anchor = styled.a`
   cursor: pointer;
 `
 
-const Logo = ({ variation }) => (
+const Logo = ({ variation, closeMenu }) => (
   <Link href="/" passHref>
-    <Anchor aria-label="Home">
+    <Anchor aria-label="Home" onClick={closeMenu}>
       <LogoImg
         src={
           variation === COLOR_VARIATIONS.dark


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [ ] 
- [x] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

- When the mobile menu is open the top-level div in the DOM `id="_next" is given the attribute of "hidden=true"
- When the close button of the mobile menu is clicked, it calls the "closeMenu" function which in turns hides the mobile menu and removes the "hidden=true" attribute from the top-level div
- The issue came from the About Link and the Commit Logo ("/") being sent to their respective routes, without actually removing this "hidden=true" attribute, therefore when we landed on either of those pages, they were blank because they were hidden
- This PR simply passes down the "closeMenu" function as a prop down to logo.js and links.js so that the function can be called on click when the user is sent to either of the routes.
- Issue: https://github.com/commitdev/commit.dev/issues/93
## Screenshots
https://www.loom.com/share/e6630b12f3e04e82b3fd7847d6be4298

<!-- Attach screenshots or a GIF showing off any visual changes; A great tool to help with this is Kap (https://getkap.co/) -->
