### PR TITLE
90 adjust the sizing of the features and articles sections

### DIFF
--- a/components/site-header/compact.js
+++ b/components/site-header/compact.js
@@ -78,7 +78,7 @@ const NavOverlay = React.forwardRef(
       return ReactDOM.createPortal(
         <NavOverlayRoot id={id} isOpen={isOpen} {...props}>
           <FauxHeader>
-            <Logo closeMenu={closeMenu}/>
+            <Logo closeMenu={closeMenu} />
             <HamburgerMenu
               isOpen={isOpen}
               handleClick={closeMenu}

--- a/components/site-header/links.js
+++ b/components/site-header/links.js
@@ -1,6 +1,9 @@
 import Link from 'next/link'
 import { rem } from 'polished'
+import { func } from 'prop-types'
 import styled from 'styled-components'
+
+import { NOOP } from 'helpers/utils'
 
 const Anchor = styled.a`
   text-decoration: none;
@@ -23,8 +26,12 @@ const Links = ({ closeMenu }) => (
   </>
 )
 
-Links.propTypes = {}
+Links.propTypes = {
+  closeMenu: func,
+}
 
-Links.defaultProps = {}
+Links.defaultProps = {
+  closeMenu: NOOP,
+}
 
 export default Links

--- a/components/site-header/logo.js
+++ b/components/site-header/logo.js
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 import { rem } from 'polished'
-import { oneOf } from 'prop-types'
+import { oneOf, func } from 'prop-types'
 import styled from 'styled-components'
 
+import { NOOP } from 'helpers/utils'
 import { COMPACT_SIZE } from 'styles/constants'
 
 import { COLOR_VARIATIONS } from './constants'
@@ -53,10 +54,12 @@ Logo.propTypes = {
   variation: oneOf(
     Object.keys(COLOR_VARIATIONS).map((k) => COLOR_VARIATIONS[k]),
   ),
+  closeMenu: func,
 }
 
 Logo.defaultProps = {
   variation: COLOR_VARIATIONS.dark,
+  closeMenu: NOOP,
 }
 
 export default Logo

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -15,9 +15,14 @@
 .gridSection {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  column-gap: 24px;
+  column-gap: 72px;
   max-width: 1240px;
   margin: 0 auto;
+}
+@media only screen and (max-width: 1023px) {
+  .gridSection {
+    column-gap: 24px;
+  }
 }
 .flexSection {
   display: flex;


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [ ] CI is green
- [x] Link to any related issues
- [ ] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Adjusts the space between features and articles on the Home page to be 72px for desktop sizes.

> Related Issue: #90 

## Screenshots

![Screen Shot 2021-02-22 at 11 51 12 AM](https://user-images.githubusercontent.com/10035832/108762015-6df4a280-7504-11eb-903d-e7317248c942.png)

