### PR TITLE
111 update the light blue sections top and bottom padding

### DIFF
--- a/sections/logo-section/index.js
+++ b/sections/logo-section/index.js
@@ -10,8 +10,12 @@ import { TABLET_LARGE_SIZE, MOBILE_SIZE } from 'styles/constants'
 const { h2 } = Heading.VARIANT
 
 const StyledSection = styled.section`
-  padding: 80px 0;
+  padding: 140px 0;
   background: #e8edf4;
+
+  @media only screen and (max-width: ${TABLET_LARGE_SIZE}) {
+    padding: 80px 0;
+  }
 
   @media only screen and (max-width: ${MOBILE_SIZE}) {
     padding: 64px 0px;

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -233,7 +233,7 @@ a.heroLink {
 
 /* About styles */
 .about {
-  padding: 100px 0px;
+  padding: 140px 0px;
 }
 .about .flexSection {
   flex-direction: row;
@@ -255,6 +255,9 @@ a.heroLink {
 }
 
 @media only screen and (max-width: 1023px) {
+  .about {
+    padding: 120px 0px;
+  }
   .about .flexSection {
     flex-direction: column;
     align-items: center;
@@ -270,6 +273,9 @@ a.heroLink {
 }
 
 @media only screen and (max-width: 449px) {
+  .about {
+    padding: 84px 0px;
+  }
   .about .aboutDescription {
     font-size: 1rem;
     line-height: 1.625rem;


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [x] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Updates the top and bottom padding of the the `How it works`, `Who we work with`, and `Our software engineers` sections to be inline with the design doc.

> Related Issue: #111 

## Screenshots

The logo sections have shared code.
### Old
![Screen Shot 2021-02-25 at 3 08 21 PM](https://user-images.githubusercontent.com/10035832/109231804-1496a880-777c-11eb-9a13-b36fec567ec4.png)
![Screen Shot 2021-02-25 at 3 08 14 PM](https://user-images.githubusercontent.com/10035832/109231806-152f3f00-777c-11eb-9021-fabf9d3bcfb4.png)

### New
![Screen Shot 2021-02-25 at 3 07 03 PM](https://user-images.githubusercontent.com/10035832/109231832-1ceee380-777c-11eb-94fd-c71345af8e0d.png)
![Screen Shot 2021-02-25 at 3 06 54 PM](https://user-images.githubusercontent.com/10035832/109231835-1d877a00-777c-11eb-8318-c317651ed797.png)
