### PR TITLE
109 add missing montserrat font weight

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700;900&family=Montserrat:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700;900&family=Montserrat:wght@500;600;700;800&display=swap');
 
 html,
 body {


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [x] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Adds in requesting the 800 weight font for `Montserrat`

> Related Issue: #109 

## Screenshots

(Left: font-weight: 800, Right: font-weight: 800 falling back to 700)
![Screen Shot 2021-02-26 at 9 55 47 AM](https://user-images.githubusercontent.com/10035832/109339630-c2599400-781c-11eb-8203-50e8ded571a9.png)

