### PR TITLE
Add left and right arrow buttons to testimonials section, for DESKTOP…

### DIFF
--- a/components/testimonials/index.js
+++ b/components/testimonials/index.js
@@ -1,10 +1,11 @@
 import { useEffect } from 'react'
 
 import Glide from '@glidejs/glide'
+import { CaretLeft, CaretRight } from 'phosphor-react'
 import { rem } from 'polished'
 import styled from 'styled-components'
 
-import { MOBILE_SIZE } from 'styles/constants'
+import { MOBILE_SIZE, TABLET_LARGE_SIZE } from 'styles/constants'
 
 import Slide from './slide'
 
@@ -13,6 +14,7 @@ import '@glidejs/glide/dist/css/glide.theme.min.css'
 
 const DOT_SIZE = rem('18px')
 const DOT_SIZE_MOBILE = rem('24px')
+const CARET_SIZE = rem('37px')
 
 const Root = styled.div`
   margin-top: ${rem('64px')};
@@ -34,6 +36,42 @@ const ControlDots = styled.div`
   justify-content: center;
   width: 100%;
   position: relative;
+`
+
+const ArrowButtons = styled.div``
+
+const ArrowButton = styled.button`
+  background: transparent;
+  border: 0;
+  color: rgba(255, 104, 186, 0.5);
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
+
+  &.glide__bullet--active {
+    background: transparent;
+  }
+
+  &:hover {
+    color: rgba(255, 104, 186, 1);
+  }
+
+  @media only screen and (max-width: ${TABLET_LARGE_SIZE}) {
+    display: none;
+  }
+`
+
+const LeftArrowButton = styled(ArrowButton)`
+  position: absolute;
+  top: 81.5px;
+`
+
+const RightArrowButton = styled(ArrowButton)`
+  position: absolute;
+  right: 0;
+  top: 81.5px;
 `
 
 const DotButton = styled.button`
@@ -102,6 +140,14 @@ const Testimonials = () => {
           </li>
         </ul>
       </Track>
+      <ArrowButtons data-glide-el="controls[nav]">
+        <LeftArrowButton aria-label="Previous" data-glide-dir="<">
+          <CaretLeft size={CARET_SIZE} />
+        </LeftArrowButton>
+        <RightArrowButton aria-label="Next" data-glide-dir=">">
+          <CaretRight size={CARET_SIZE} />
+        </RightArrowButton>
+      </ArrowButtons>
       <ControlDots data-glide-el="controls[nav]">
         <DotButton
           type="button"


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [ ] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Add left and right arrow buttons using Phosphor caret-left, caret-right components. Add highlight color on hover. Display only for desktop size.

> Related Issue: Add arrows to the testimonial section (https://github.com/commitdev/commit.dev/issues/107)

## Screenshots


https://user-images.githubusercontent.com/75385657/109351762-a4952a80-782e-11eb-85ce-f71218d191a2.mov

