### PR TITLE
118 fix styling of exec members to prevent mismatched columns

### DIFF
--- a/sections/executive-team-section/executive-avatar.js
+++ b/sections/executive-team-section/executive-avatar.js
@@ -6,11 +6,14 @@ import styled from 'styled-components'
 
 import { TABLET_SMALL_SIZE } from 'styles/constants'
 
+const WIDTH = rem('160px')
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  align-self: flex-start;
   padding: ${rem('32px')};
 
   @media only screen and (max-width: ${TABLET_SMALL_SIZE}) {
@@ -20,7 +23,7 @@ const Container = styled.div`
 
 const Avatar = styled.img`
   border-radius: 100%;
-  width: ${rem('160px')};
+  width: ${WIDTH};
 `
 
 const Name = styled.div`
@@ -30,12 +33,15 @@ const Name = styled.div`
   padding-top: ${rem('24px')};
 `
 
-const Position = styled.div`
+const Position = styled.span`
   font-size: 16px;
   font-weight: 600;
   color: #657594;
-  padding-top: ${rem('8px')};
+  padding: ${rem('8px')} ${rem('4px')} 0;
   text-transform: capitalize;
+  text-align: center;
+  line-height: ${rem('18px')};
+  max-width: ${WIDTH};
 `
 
 const ExecutiveAvatar = ({ name, postion, src }) => (


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [x] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Updated the styling of the exec members section on the about page to avoid mixed single and double column layouts.

> Related Issue: #118 

## Screenshots

### Before:
![Kapture 2021-02-26 at 15 32 59](https://user-images.githubusercontent.com/10035832/109367156-29da0880-784a-11eb-9044-9f736ed95f28.gif)


### After:
![Kapture 2021-02-26 at 15 34 59](https://user-images.githubusercontent.com/10035832/109367165-2f375300-784a-11eb-981a-7f51658af15d.gif)
