### PR TITLE
130 prevent css flicker on initial load from styled-components

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,43 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+
+// styled-components code from https://styled-components.com/docs/advanced#nextjs
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [x] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Adds in styled-components recommend server side rendering logic to prevent flicker on page load.

> Related Issue: #130 

## Screenshots

#### Before:
![Kapture 2021-03-01 at 09 15 44](https://user-images.githubusercontent.com/10035832/109566096-3eabdb80-7a98-11eb-82d7-a05211de107b.gif)

#### After:
![Kapture 2021-03-01 at 11 36 31](https://user-images.githubusercontent.com/10035832/109566106-423f6280-7a98-11eb-84d8-4abc8847d421.gif)
