### PR TITLE
129 adjust line height and update alignment of articles on home page

### DIFF
--- a/components/article-preview/index.js
+++ b/components/article-preview/index.js
@@ -1,3 +1,6 @@
+import React from 'react'
+
+import { rem } from 'polished'
 import { string } from 'prop-types'
 import styled from 'styled-components'
 
@@ -25,9 +28,14 @@ const Root = styled.div`
   h3 {
     font-size: 1rem;
     font-weight: 700;
-    line-height: 1.625rem;
-    margin: 1.25rem 0px;
+    line-height: ${rem('21px')};
+    height: 4rem;
+    margin: 1.25rem 0;
     text-align: center;
+
+    @media only screen and (max-width: ${MOBILE_SIZE}) {
+      height: auto;
+    }
   }
 
   p {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700;900&family=Montserrat:wght@500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;600;700;900&family=Montserrat:wght@500;600;700;800&display=swap');
 
 html,
 body {


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [ ] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Fixes the line-height for the titles in the articles section and aligns the start of the articles.

> Related Issue: #129 

## Screenshots

#### Before:
![Screen Shot 2021-03-02 at 3 56 55 PM](https://user-images.githubusercontent.com/10035832/109731597-6c645380-7b70-11eb-9b17-00d61db6b3e3.png)

#### After:
![Screen Shot 2021-03-02 at 3 57 06 PM](https://user-images.githubusercontent.com/10035832/109731593-6a9a9000-7b70-11eb-8a3d-726dc43981b7.png)