### PR TITLE
163 fix line wrapping of apply button in firefox

### DIFF
--- a/components/apply-link/index.js
+++ b/components/apply-link/index.js
@@ -21,6 +21,7 @@ const StyledLink = styled.a`
   text-transform: uppercase;
   text-decoration-line: none;
   font-family: inherit;
+  white-space: nowrap;
 
   :hover {
     background: linear-gradient(


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [x] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Fixes the `apply to join us` button wrapping on to a second line in Firefox.

> Related Issue: #163 

## Screenshots

### Before
![Screen Shot 2021-03-09 at 9 47 55 AM](https://user-images.githubusercontent.com/10035832/110515026-c7d89900-80bc-11eb-8e3c-952d7f37af91.png)


### After
![Screen Shot 2021-03-09 at 9 48 00 AM](https://user-images.githubusercontent.com/10035832/110515041-cad38980-80bc-11eb-91b6-b9cd5a30cd3a.png)
