### PR TITLE
158 have launch take over commit-staging.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ workflows:
             - checkout_code
       - deploy:
           name: deploy_staging
-          bucket: launch.commit-staging.dev
+          bucket: commit-staging.dev
           requires:
             - build_feature
       - e2e:


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [ ] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Since we're nearing launch have the launch branch start pushing to commit-staging.dev so apply can be tested with confidence. The `COMMIT_DEV_HOST` environment variable will need to be changed as well.

> Related Issue: #158 
