### PR TITLE
Change header styles based on current scroll position

### DIFF
--- a/components/site-header/index.js
+++ b/components/site-header/index.js
@@ -3,38 +3,51 @@ import styled from 'styled-components'
 
 import { TABLET_SMALL_SIZE, COLOR_VARIATIONS } from 'styles/constants'
 
+import useIsScrolledFromTop from '../../helpers/hooks/use-is-scrolled-from-top'
 import CompactMenu from './compact'
 import Logo from './logo'
 import StandardMenu from './standard'
 
 const StyledHeader = styled.header`
-  position: sticky;
+  position: fixed;
   top: 0;
+  width: 100%;
   z-index: 100;
   font-size: ${rem('16px')};
   font-weight: 500;
   letter-spacing: 0em;
   text-align: left;
-  background-color: rgba(255, 255, 255, 0.5);
+  transition: background-color 200ms ease-in-out, padding 200ms ease-in-out;
+  background-color: ${({ isScrolled }) =>
+    isScrolled ? 'rgba(255, 255, 255, 0.5)' : 'rgba(255, 255, 255, 0)'};
 
   display: flex;
   align-items: center;
   justify-content: space-between;
 
   padding: ${rem('14px')} ${rem('54px')};
+  padding-top: ${({ isScrolled }) => (isScrolled ? rem('14px') : rem('32px'))};
+
   @media only screen and (max-width: ${TABLET_SMALL_SIZE}) {
     line-height: 0.5;
     padding: ${rem('24px')};
   }
 `
 
-const SiteHeader = () => (
-  <StyledHeader>
-    <Logo variation={COLOR_VARIATIONS.light} />
-    <StandardMenu variation={COLOR_VARIATIONS.light} />
-    <CompactMenu variation={COLOR_VARIATIONS.light} />
-  </StyledHeader>
-)
+const SiteHeader = () => {
+  const isScrolledFromTop = useIsScrolledFromTop(10, 40)
+  const colorVariation = isScrolledFromTop
+    ? COLOR_VARIATIONS.light
+    : COLOR_VARIATIONS.dark
+
+  return (
+    <StyledHeader isScrolled={isScrolledFromTop}>
+      <Logo variation={colorVariation} />
+      <StandardMenu variation={colorVariation} />
+      <CompactMenu variation={colorVariation} />
+    </StyledHeader>
+  )
+}
 
 SiteHeader.VARIATIONS = COLOR_VARIATIONS
 

--- a/components/site-header/standard.js
+++ b/components/site-header/standard.js
@@ -8,6 +8,8 @@ const Nav = styled.nav`
   a {
     color: ${(p) =>
       p.variation === COLOR_VARIATIONS.dark ? '#ffffff' : '#010242'};
+
+    transition: color 200ms ease-in-out;
   }
   @media only screen and (max-width: ${TABLET_SMALL_SIZE}) {
     display: none;

--- a/helpers/hooks/use-is-scrolled-from-top.js
+++ b/helpers/hooks/use-is-scrolled-from-top.js
@@ -1,0 +1,25 @@
+import { useRef, useState } from 'react'
+
+import { useScrollPosition } from './use-scroll-position'
+
+function useIsScrolledFromTop(offset = 0, throttleDelay) {
+  const isScrolledFromTopRef = useRef(false)
+  const [isScrolledFromTopState, setIsScrolledFromTop] = useState(false)
+
+  useScrollPosition(
+    ({ y }) => {
+      const isScrolledFromTop = y > offset
+
+      if (isScrolledFromTop !== isScrolledFromTopRef.current) {
+        isScrolledFromTopRef.current = isScrolledFromTop
+        setIsScrolledFromTop(isScrolledFromTop)
+      }
+    },
+    [],
+    throttleDelay,
+  )
+
+  return isScrolledFromTopState
+}
+
+export default useIsScrolledFromTop

--- a/helpers/hooks/use-scroll-position.js
+++ b/helpers/hooks/use-scroll-position.js
@@ -1,0 +1,36 @@
+import { useEffect } from 'react'
+
+const SCROLL_EVENT_TYPE = 'scroll'
+
+function getScrollPosition() {
+  if (!process.browser) {
+    return { x: 0, y: 0 }
+  }
+
+  return { x: window.scrollX, y: window.scrollY }
+}
+
+export function useScrollPosition(effect, deps, throttleDelay) {
+  let throttleTimeout = null
+
+  const callBack = () => {
+    effect(getScrollPosition())
+    throttleTimeout = null
+  }
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (throttleDelay) {
+        if (throttleTimeout === null) {
+          throttleTimeout = setTimeout(callBack, throttleDelay)
+        }
+      } else {
+        callBack()
+      }
+    }
+
+    window.addEventListener(SCROLL_EVENT_TYPE, handleScroll)
+
+    return () => window.removeEventListener(SCROLL_EVENT_TYPE, handleScroll)
+  }, deps)
+}


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [ ] CI is green
- [ ] Link to any related issues
- [ ] Received at least 1 approval from core members
- [ ] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

- Use white text and dark background if page scroll is at the top and use dark text on white if page is scrolled more than a fixed offset (set to 10 px)
- same scroll offset is used to change header top padding
- CSS animation set to 200 ms with `ease-in-out` effect for smooth style changes

fix #193

## Screenshots

![Apr-05-2021 14-07-35](https://user-images.githubusercontent.com/832191/113627506-7a4a4000-9618-11eb-8109-808d0669c92b.gif)

![Apr-05-2021 14-08-41](https://user-images.githubusercontent.com/832191/113627517-7dddc700-9618-11eb-8801-335a213baed8.gif)

