### PR TITLE
Fix header to show light variant on pages that are not the home page

### DIFF
--- a/components/site-header/index.js
+++ b/components/site-header/index.js
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { rem } from 'polished'
 import styled from 'styled-components'
 
@@ -18,9 +19,10 @@ const StyledHeader = styled.header`
   letter-spacing: 0em;
   text-align: left;
   transition: background-color 200ms ease-in-out, padding 200ms ease-in-out;
-  background-color: ${({ isScrolled }) =>
-    isScrolled ? 'rgba(255, 255, 255, 0.5)' : 'rgba(255, 255, 255, 0)'};
-
+  background-color: ${({ variation }) =>
+    variation === COLOR_VARIATIONS.light
+      ? 'rgba(255, 255, 255, 0.5)'
+      : 'rgba(255, 255, 255, 0)'};
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -34,14 +36,24 @@ const StyledHeader = styled.header`
   }
 `
 
+const pagesWithDarkHeroDict = ['/', '/apply']
+
+const usePageWithDarkHero = () => {
+  const router = useRouter()
+  return pagesWithDarkHeroDict.indexOf(router.pathname) !== -1
+}
+
 const SiteHeader = () => {
+  const pageWithDarkHero = usePageWithDarkHero()
   const isScrolledFromTop = useIsScrolledFromTop(10, 40)
-  const colorVariation = isScrolledFromTop
-    ? COLOR_VARIATIONS.light
-    : COLOR_VARIATIONS.dark
+
+  const colorVariation =
+    !pageWithDarkHero || isScrolledFromTop
+      ? COLOR_VARIATIONS.light
+      : COLOR_VARIATIONS.dark
 
   return (
-    <StyledHeader isScrolled={isScrolledFromTop}>
+    <StyledHeader variation={colorVariation} isScrolled={isScrolledFromTop}>
       <Logo variation={colorVariation} />
       <StandardMenu variation={colorVariation} />
       <CompactMenu variation={colorVariation} />


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [ ] CI is green
- [ ] Link to any related issues
- [ ] Received at least 1 approval from core members
- [ ] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Fix header to show light variant on pages that are not the home page.
Before this change the header doesn't show on the about page.

## Screenshots

![Screen Shot 2021-04-07 at 12 29 02 PM](https://user-images.githubusercontent.com/832191/113923037-e81f7480-979c-11eb-9289-088dcee7ea34.png)

![Screen Shot 2021-04-07 at 12 28 59 PM](https://user-images.githubusercontent.com/832191/113923043-ebb2fb80-979c-11eb-8d8d-8ec0610b9349.png)
