### PR TITLE
244 Add padding to executive team avatars to prevent touching

### DIFF
--- a/sections/executive-team-section/executive-avatar.js
+++ b/sections/executive-team-section/executive-avatar.js
@@ -34,6 +34,7 @@ const Container = styled.div`
 const AvatarContainer = styled(MediaContainer)`
   width: 100%;
   max-width: 160px;
+  padding: 0 5px;
 
   @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
     max-width: 140px;

--- a/sections/executive-team-section/executive-avatar.js
+++ b/sections/executive-team-section/executive-avatar.js
@@ -33,11 +33,12 @@ const Container = styled.div`
 
 const AvatarContainer = styled(MediaContainer)`
   width: 100%;
-  max-width: 160px;
-  padding: 0 5px;
+  max-width: ${rem('180px')};
+  padding: 0 ${rem('10px')};
 
   @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
-    max-width: 140px;
+    max-width: ${rem('140px')};
+    padding: 0;
   }
 `
 

--- a/sections/executive-team-section/index.js
+++ b/sections/executive-team-section/index.js
@@ -37,7 +37,7 @@ const AvatarList = styled.div`
   justify-content: center;
   margin: 0 auto;
   max-width: ${rem('1240px')};
-  padding: 0 ${rem('35px')};
+  padding: 0 ${rem('26px')};
 
   @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
     padding: 0 ${rem('40px')};


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [ ] CI is green
- [ ] Link to any related issues
- [ ] Received at least 1 approval from core members
- [ ] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Added 5px of padding on either side of executive team avatars to prevent touching images at smaller mobile resolutions.

> Related Issue: https://github.com/commitdev/commit.dev/issues/244

- TODO

## Screenshots

<img width="374" alt="Screen Shot 2021-04-12 at 2 56 07 PM" src="https://user-images.githubusercontent.com/18448266/114467770-3bc7fe80-9b9f-11eb-9347-563d2472d78d.png">

