### PR TITLE
fix sp section layout on mobile

### DIFF
--- a/components/logo/index.js
+++ b/components/logo/index.js
@@ -9,6 +9,7 @@ const Anchor = styled.a`
   min-width: 11.25rem;
   opacity: 0.5;
   transition: opacity 200ms ease-in-out;
+  display: block;
 
   :hover {
     opacity: 0.75;
@@ -16,7 +17,7 @@ const Anchor = styled.a`
 `
 
 const Logo = ({ url, name, alt }) => (
-  <Anchor href={url} rel="noopener noreferrer">
+  <Anchor href={url} rel="noopener noreferrer" target="_blank">
     <StaticImage alt={alt} name={`logos/${name}`} />
   </Anchor>
 )

--- a/components/media/image.js
+++ b/components/media/image.js
@@ -6,6 +6,7 @@ const StyledImage = styled.img`
   display: block;
   width: 100%;
   height: auto;
+  transform: translateZ(0);
 
   :not([src]) {
     visibility: hidden;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import { Footer, Logo, Page } from 'components'
+import { Footer, Page } from 'components'
 import {
   EngineersWhoJoinedSection,
   FeaturedArticles,
@@ -14,25 +14,7 @@ import {
 const Home = () => (
   <Page>
     <HomeHero />
-    <SpSection>
-      <Logo
-        url="https://www.procurify.com/"
-        alt="Procurify logo"
-        name="procurify.png"
-      />
-      <Logo url="https://certn.co/" alt="Certn logo" name="certn.png" />
-      <Logo
-        url="https://www.dapperlabs.com/"
-        alt="Dapper logo"
-        name="dapper.png"
-      />
-      <Logo url="https://www.usepatch.com/" alt="Patch logo" name="patch.png" />
-      <Logo
-        url="https://www.plastiq.com/"
-        alt="Plastiq logo"
-        name="plastiq.png"
-      />
-    </SpSection>
+    <SpSection />
     <HowItWorks />
     <FeaturedArticles />
     <TimelineSection />

--- a/sections/sp-section/index.js
+++ b/sections/sp-section/index.js
@@ -1,12 +1,11 @@
 import React from 'react'
 
 import { rem } from 'polished'
-import { arrayOf, element } from 'prop-types'
 import styled from 'styled-components'
 
-import { RowContainer } from 'components'
+import { RowContainer, Logo } from 'components'
 import { FlexSectionContent } from 'components/layout'
-import { TABLET_SMALL_SIZE } from 'styles/constants'
+import { TABLET_SMALL_SIZE, TABLET_LARGE_SIZE } from 'styles/constants'
 
 import { SectionHeading } from '../../components/heading'
 import SectionHeadingContainer from '../../components/section-heading-container'
@@ -22,22 +21,47 @@ const StyledFlexSectionContent = styled(FlexSectionContent)`
   align-items: center;
 `
 
-const LogoContainer = styled(RowContainer)`
+const LogosContainer = styled(RowContainer)`
   margin-top: ${rem(56)};
+  margin-right: -1rem;
+  margin-left: -1rem;
+  width: auto;
 
   @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
+    width: 100%;
     margin-top: ${rem(92)};
   }
 `
 
+const LogoContainer = styled.div`
+  max-width: 50%;
+  flex: 0 0 50%;
+  padding: 0 1rem;
+
+  @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
+    max-width: 33.33%;
+    flex: 0 0 33.33%;
+  }
+
+  @media only screen and (min-width: ${TABLET_LARGE_SIZE}) {
+    max-width: 160px;
+    min-width: 160px;
+    flex: 1;
+  }
+`
+
 const Explanation = styled.p`
-  margin-top: 6.5rem;
+  margin-top: ${rem(94)};
   text-align: center;
   font-family: 'Lato';
   line-height: 1.25rem;
+
+  @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
+    margin-top: ${rem(104)};
+  }
 `
 
-const SpSection = ({ children }) => (
+const SpSection = () => (
   <StyledSection>
     <StyledFlexSectionContent>
       <SectionHeadingContainer>
@@ -45,7 +69,39 @@ const SpSection = ({ children }) => (
           We only let the most promising startups on our platform<sup>*</sup>
         </SectionHeading>
       </SectionHeadingContainer>
-      <LogoContainer>{children}</LogoContainer>
+      <LogosContainer>
+        <LogoContainer>
+          <Logo
+            url="https://www.procurify.com/"
+            alt="Procurify logo"
+            name="procurify.png"
+          />
+        </LogoContainer>
+        <LogoContainer>
+          <Logo url="https://certn.co/" alt="Certn logo" name="certn.png" />
+        </LogoContainer>
+        <LogoContainer>
+          <Logo
+            url="https://www.dapperlabs.com/"
+            alt="Dapper logo"
+            name="dapper.png"
+          />
+        </LogoContainer>
+        <LogoContainer>
+          <Logo
+            url="https://www.usepatch.com/"
+            alt="Patch logo"
+            name="patch.png"
+          />
+        </LogoContainer>
+        <LogoContainer>
+          <Logo
+            url="https://www.plastiq.com/"
+            alt="Plastiq logo"
+            name="plastiq.png"
+          />
+        </LogoContainer>
+      </LogosContainer>
       <Explanation>
         <sup>*</sup>We partner with startups that are on track to become
         category leading public companies, with cultures that prioritize
@@ -54,9 +110,5 @@ const SpSection = ({ children }) => (
     </StyledFlexSectionContent>
   </StyledSection>
 )
-
-SpSection.propTypes = {
-  children: arrayOf(element),
-}
 
 export default SpSection


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [ ] CI is green
- [ ] Link to any related issues
- [ ] Received at least 1 approval from core members
- [ ] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

- fix sp section layout on mobile
- open links on new tab
- applied `transform` css attribute to improve crispness of images (especially logos)

fix #255

## Screenshots

![Screen Shot 2021-04-14 at 2 51 38 PM](https://user-images.githubusercontent.com/832191/114785120-0d7a2880-9d31-11eb-9f33-1a87b71b95a9.png)
![Screen Shot 2021-04-14 at 2 51 54 PM](https://user-images.githubusercontent.com/832191/114785128-0f43ec00-9d31-11eb-9742-0ed44d4a6a74.png)
![Screen Shot 2021-04-14 at 2 52 09 PM](https://user-images.githubusercontent.com/832191/114785133-110daf80-9d31-11eb-9f96-395e0fc8f722.png)
