### PR TITLE
289 - fixed bugs found in Safari QA

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -39,7 +39,8 @@ const StyledApplyLink = styled.a`
   display: block;
   background: #ff68ba;
   background: linear-gradient(90.03deg, #ff68ba 0.39%, #edc281 99.97%);
-  width: ${props => props.customWidth ? rem(props.customWidth) : rem('256px')};
+  width: ${(props) =>
+    props.customWidth ? rem(props.customWidth) : rem('256px')};
   padding: ${rem('15px')} ${rem('42px')};
   border: 0;
   border-radius: 48px;
@@ -68,7 +69,7 @@ const StyledApplyLink = styled.a`
     }
     :after {
       z-index: 1;
-      background: ${props => props.hoverBackground || '#100c1c'};
+      background: ${(props) => props.hoverBackground || '#100c1c'};
       border-radius: 48px;
       content: '';
       position: absolute;
@@ -93,7 +94,11 @@ const StyledApplyLink = styled.a`
   }
 `
 
-const ApplyLink = ({ href = '/apply', text = 'Join the waitlist', ...props }) => (
+const ApplyLink = ({
+  href = '/apply',
+  text = 'Join the waitlist',
+  ...props
+}) => (
   <Link {...{ href, text }} passHref>
     <StyledApplyLink rel="noopener" {...props}>
       <span>{text}</span>

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -35,17 +35,17 @@ const StyledButton = styled.button`
   }
 `
 
-const StyledLink = styled.a`
+const StyledApplyLink = styled.a`
   display: block;
   background: #ff68ba;
   background: linear-gradient(90.03deg, #ff68ba 0.39%, #edc281 99.97%);
-  width: ${props => props.customWidth ? rem(props.customWidth) : rem('316px')};
+  width: ${props => props.customWidth ? rem(props.customWidth) : rem('256px')};
   padding: ${rem('15px')} ${rem('42px')};
   border: 0;
   border-radius: 48px;
   font-weight: bold;
-  font-size: ${rem('24px')};
-  line-height: ${rem('29px')};
+  font-size: ${rem('18px')};
+  line-height: ${rem('30px')};
   text-align: center;
   color: #000;
   cursor: pointer;
@@ -80,7 +80,6 @@ const StyledLink = styled.a`
     }
   }
 
-
   :active,
   :focus {
     opacity: 0.7;
@@ -88,28 +87,18 @@ const StyledLink = styled.a`
   }
 
   @media only screen and (max-width: ${MOBILE_SIZE}) {
-    font-size: ${rem('18px')};
-    line-height: ${rem('22px')};
-    padding: ${rem('16px')};
+    font-size: ${rem('16px')};
+    line-height: ${rem('20px')};
     width: 100%;
   }
 `
 
-const LinkButton = ({ href, text, ...props }) => (
+const ApplyLink = ({ href = '/apply', text = 'Join the waitlist', ...props }) => (
   <Link {...{ href, text }} passHref>
-    <StyledLink rel="noopener" {...props}>
+    <StyledApplyLink rel="noopener" {...props}>
       <span>{text}</span>
-    </StyledLink>
+    </StyledApplyLink>
   </Link>
-)
-
-LinkButton.propTypes = {
-  href: string.isRequired,
-  text: string.isRequired,
-}
-
-const ApplyLink = ({ href = '/apply', text = 'Join the waitlist', ...props } ) => (
-  <LinkButton {...{href, text, ...props}} />
 )
 
 ApplyLink.propTypes = {

--- a/components/footer/index.js
+++ b/components/footer/index.js
@@ -17,13 +17,12 @@ const FooterContainer = styled.footer`
   background: linear-gradient(68.66deg, #0f1011 0%, #010242 100%);
 
   @media only screen and (max-width: ${MOBILE_SIZE}) {
-    padding: 98px 0 48px;
+    padding: 150px 0 48px;
   }
 `
 
 const StyledApplyLink = styled(ApplyLink)`
-  max-width: 23.75rem;
-  margin-bottom: 200px;
+  margin-bottom: 160px;
 
   @media only screen and (max-width: ${MOBILE_SIZE}) {
     margin-bottom: 124px;
@@ -100,16 +99,18 @@ const SiteLinksContainer = styled.div`
 `
 
 const FooterHeading = styled(SectionHeadingBold)`
-  text-align: center;
-  color: #fff;
   margin-bottom: 4rem;
+
+  @media only screen and (max-width: ${TABLET_LARGE_SIZE}) {
+    font-size: 24px;
+  }
 `
 
 const Footer = (props) => (
   <FooterContainer {...props}>
     <FlexSection>
       <FooterHeading>Let’s get started</FooterHeading>
-      <StyledApplyLink hoverBackground="#100c2c" customWidth="330px" />
+      <StyledApplyLink hoverBackground="#100c2c" />
     </FlexSection>
     <BottomContainer>
       <CommitLogo alt="Commit logo" src="/commit-logo.svg" />

--- a/components/social-icons/index.js
+++ b/components/social-icons/index.js
@@ -28,7 +28,7 @@ const SocialIcons = ({ size }) => (
         size={size}
       />
     </SocialLink>
-    <SocialLink href="https://www.linkedin.com/company/commitdev/mycompany/">
+    <SocialLink href="https://www.linkedin.com/company/commitdev/">
       <StyledImg
         alt="Commit's LinkedIn company page"
         src="/logo-linkedin.svg"

--- a/components/testimonials/index.js
+++ b/components/testimonials/index.js
@@ -15,7 +15,7 @@ import '@glidejs/glide/dist/css/glide.theme.min.css'
 
 const DOT_SIZE = rem('18px')
 const DOT_SIZE_MOBILE = rem('24px')
-const CARET_SIZE = rem('37px')
+const CARET_SIZE = rem('50px')
 
 const Root = styled.div`
   margin-top: ${rem('42px')};

--- a/components/testimonials/slide.js
+++ b/components/testimonials/slide.js
@@ -2,7 +2,7 @@ import { rem } from 'polished'
 import { string } from 'prop-types'
 import styled from 'styled-components'
 
-import { Text, MediaContainer } from 'components'
+import { MediaContainer } from 'components'
 import {
   TABLET_SMALL_SIZE,
   TABLET_LARGE_SIZE,
@@ -86,13 +86,22 @@ const SlideSubHeading = styled(SubHeading)`
   }
 `
 
+const SlideText = styled(SubHeading)`
+  && {
+    font-size: ${rem(16)};
+    font-weight: 400;
+    line-height: 1.5;
+    margin-top: ${rem(16)};
+  }
+`
+
 const Slide = ({ media, heading, subHeading, text, ...props }) => (
   <Root {...props}>
     <SlideMediaContainer>{media}</SlideMediaContainer>
     <Content>
       <SlideHeading>{heading}</SlideHeading>
       <SlideSubHeading as="p">{subHeading}</SlideSubHeading>
-      <Text>{text}</Text>
+      <SlideText>{text}</SlideText>
     </Content>
   </Root>
 )

--- a/sections/diversity-and-inclusion-section/index.js
+++ b/sections/diversity-and-inclusion-section/index.js
@@ -4,12 +4,12 @@ import { rem } from 'polished'
 import styled from 'styled-components'
 
 import { MediaContainer, StaticImage, Text } from 'components'
-import { MOBILE_SIZE, TABLET_LARGE_SIZE } from 'styles/constants'
+import { MOBILE_SIZE, TABLET_SMALL_SIZE } from 'styles/constants'
 
 import { SectionHeadingBold } from '../../components/heading'
 
 const Container = styled.div`
-  @media only screen and (min-width: ${TABLET_LARGE_SIZE}) {
+  @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
     display: grid;
     grid-template-columns: 50% 50%;
   }
@@ -23,7 +23,7 @@ const ImageContainer = styled(MediaContainer)`
     padding-bottom: 70%;
   }
 
-  @media only screen and (min-width: ${TABLET_LARGE_SIZE}) {
+  @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
     grid-row-start: 1;
     height: auto;
     min-height: ${rem('534px')};
@@ -50,7 +50,7 @@ const StyledHeading = styled(SectionHeadingBold)`
   text-align: center;
   margin-bottom: ${rem('32px')};
 
-  @media only screen and (min-width: ${TABLET_LARGE_SIZE}) {
+  @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
     margin-bottom: ${rem('26px')};
   }
 `

--- a/sections/engineers-who-joined-section/index.js
+++ b/sections/engineers-who-joined-section/index.js
@@ -14,7 +14,7 @@ import { SectionHeading } from '../../components/heading'
 import SectionHeadingContainer from '../../components/section-heading-container'
 
 const StyledSection = styled.section`
-  padding: 7.5rem 1.25rem 8.75rem;
+  padding: 8.5rem 1.25rem;
   background: #e8edf4;
 `
 
@@ -52,7 +52,6 @@ const Project = styled.li`
 
 const ProjectName = styled.span`
   font-family: 'Lato';
-  font-weight: 600;
   line-height: 1.25rem;
   margin-top: 2rem;
 
@@ -85,7 +84,7 @@ const EngineersWhoJoinedSection = () => (
         <Project>
           <HealthcareSecurity title="Security Infrastructure for Healthcare logo" />
           <ProjectName>
-            The Security Infrastructure for Healthcare system
+            The Security Infrastructure for Healthcare systems
           </ProjectName>
         </Project>
         <Project>

--- a/sections/ep-built-startups-section/index.js
+++ b/sections/ep-built-startups-section/index.js
@@ -32,8 +32,6 @@ const StyledText = styled.div`
   text-align: center;
   font-family: 'Lato';
   line-height: 1.625rem;
-  margin-right: -1rem;
-  margin-left: -1rem;
 `
 
 const LogosContainer = styled(RowContainer)`

--- a/sections/executive-team-section/index.js
+++ b/sections/executive-team-section/index.js
@@ -4,7 +4,11 @@ import { rem } from 'polished'
 import styled from 'styled-components'
 
 import { useIsMaxScreenSize } from 'helpers/hooks'
-import { TABLET_LARGE_SIZE, TABLET_SMALL_SIZE } from 'styles/constants'
+import {
+  TABLET_LARGE_SIZE,
+  TABLET_SMALL_SIZE,
+  MOBILE_ONLY,
+} from 'styles/constants'
 
 import { SectionHeadingBold } from '../../components/heading'
 import ChevronSvg from '../../static/icons/chevron.svg'
@@ -18,6 +22,10 @@ const StyledSection = styled.section`
 
   @media only screen and (max-width: ${TABLET_LARGE_SIZE}) {
     padding: ${rem(124)} 0;
+  }
+
+  ${MOBILE_ONLY} {
+    padding: ${rem(124)} ${rem(16)};
   }
 `
 

--- a/sections/featured-articles-section/index.js
+++ b/sections/featured-articles-section/index.js
@@ -7,7 +7,7 @@ import { TABLET_LARGE_SIZE, MOBILE_SIZE } from 'styles/constants'
 import { SectionHeadingBold } from '../../components/heading'
 
 const StyledSection = styled.section`
-  margin: 165px auto 0;
+  margin: 122px auto 0;
   padding: 0 20px;
 
   @media only screen and (max-width: ${TABLET_LARGE_SIZE}) {

--- a/sections/home-hero-section/index.js
+++ b/sections/home-hero-section/index.js
@@ -90,13 +90,6 @@ const HeroTextExtra = styled.span`
 
 const HeroApplyLink = styled(ApplyLink)`
   margin-bottom: 5.3em;
-  font-size: 1.125em;
-  line-height: 1.375em;
-
-  ${MOBILE_ONLY} {
-    max-width: 100%;
-    min-width: 100%;
-  }
 
   ${TABLET_LARGE_ONLY} {
     margin-bottom: 8.5em;

--- a/sections/opensource-section/index.js
+++ b/sections/opensource-section/index.js
@@ -107,10 +107,11 @@ const OpensourceSection = () => {
             are the faces behind the creation of the website.
           </StyledText>
           <StyledText>
-            Feel free to checkout commit.dev’s github&nbsp;
+            Feel free to check out our&nbsp;
             <Link href="https://github.com/commitdev" passHref>
-              <PinkLink>Here</PinkLink>
+              <PinkLink>GitHub</PinkLink>
             </Link>
+            !
           </StyledText>
         </TextContent>
         <AvatarList className="pretty-scatter">

--- a/sections/platform-section/index.js
+++ b/sections/platform-section/index.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { linearGradient, rem } from 'polished'
 import styled from 'styled-components'
 
-import { TABLET_LARGE_SIZE, TABLET_SMALL_SIZE } from 'styles/constants'
+import { TABLET_SMALL_SIZE } from 'styles/constants'
 
 import FeaturesList from '../../components/features-list'
 import CommunityFeature from './features/community'
@@ -22,11 +22,7 @@ const PlatformContainer = styled.section`
   ${PLATFORM_BACKGROUND_GRAD}
 
   @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
-    padding: ${rem('140px')} 0;
-  }
-
-  @media only screen and (min-width: ${TABLET_LARGE_SIZE}) {
-    padding: ${rem('164px')} 0;
+    padding: ${rem('194px')} 0;
   }
 `
 

--- a/sections/platform-section/platform-hero.js
+++ b/sections/platform-section/platform-hero.js
@@ -34,8 +34,8 @@ const PlatformHeroHeading = styled(SectionHeadingBold)`
 
 const PlatformHeroText = styled(Text)`
   font-weight: 600;
-  font-size: ${rem('21px')};
-  line-height: 1.5;
+  font-size: ${rem('18px')};
+  line-height: 1.75;
   margin: 0 auto;
   padding: ${rem('24px')} 0 0 0;
   max-width: ${rem('790px')};

--- a/sections/sp-section/index.js
+++ b/sections/sp-section/index.js
@@ -11,7 +11,7 @@ import { SectionHeading } from '../../components/heading'
 import SectionHeadingContainer from '../../components/section-heading-container'
 
 const StyledSection = styled.section`
-  padding: 5rem 1.25rem;
+  padding: 8rem 1.25rem 4rem 1.25rem;
   background: #e8edf4;
 `
 
@@ -57,7 +57,6 @@ const Explanation = styled.p`
   margin-top: ${rem(94)};
   text-align: center;
   font-family: 'Lato';
-  line-height: 1.25rem;
 
   @media only screen and (min-width: ${TABLET_SMALL_SIZE}) {
     margin-top: ${rem(104)};

--- a/sections/testimonials/index.js
+++ b/sections/testimonials/index.js
@@ -6,7 +6,7 @@ import SectionHeadingContainer from '../../components/section-heading-container'
 import Testimonials from '../../components/testimonials'
 
 const Section = styled.section`
-  padding: 124px 0px 98px;
+  padding: 160px 0px 150px;
 `
 
 const Container = styled(SectionContainer)`

--- a/styles/about.module.css
+++ b/styles/about.module.css
@@ -79,7 +79,7 @@ h1.heroHeading {
 p.heroText {
   font-family: Lato;
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: 400;
   line-height: 2.25rem;
   margin-bottom: 8.75rem;
   text-align: left;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;600;700;900&family=Montserrat:wght@400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;600;700;900&family=Montserrat:wght@300;400;500;600;700;800&display=swap');
 
 html,
 body {


### PR DESCRIPTION
## Reminder

> Please ensure the following criteria is met for this PR. It will help others review your PR and provide confidence things work as expected.

- [x] CI is green
- [x] Link to any related issues
- [ ] Received at least 1 approval from core members
- [x] Made sure that changes are obvious for the reviewer (ex meaningful title and commit messages, comments in code or PR where appropriate, screenshots, etc.)

# What Changed?

Homepage:
- Many margin and font-size changes (see #289 for details)
- We were only using `StyledLink` (in button/index.js) for the Apply button links, so I removed some unneeded abstraction to simplify it. 
- Added an "s" to the end of "The Security Infrastructure for Healthcare system"

About page:
- Diversity section breaks into 2 rows when it's at or below the small tablet width (instead of large tablet)
- padding for "ep build startups" and "executive team" sections
- slight change to the last sentence in the "opensource" section

> Related Issue: #289 

- TODO

## Screenshots

<!-- Attach screenshots or a GIF showing off any visual changes; A great tool to help with this is Kap (https://getkap.co/) -->
Pretty much everything on the Home and About pages were changed slightly, so it would be best to run this branch locally and compare with staging to see the changes.